### PR TITLE
Implement user authentication with signin and profile retrieval endpo…

### DIFF
--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable prettier/prettier */
 import { Test, TestingModule } from '@nestjs/testing';
 import { INestApplication } from '@nestjs/common';
 import * as request from 'supertest';


### PR DESCRIPTION
…ints

- Added `signin` endpoint in `UserController` for user authentication, including password validation and JWT token generation.
- Introduced `SignInDto` for validating signin requests.
- Created `getMe` endpoint to retrieve user profile information based on JWT token.
- Enhanced end-to-end tests in `app.controller.spec.ts` to cover user authentication scenarios, including successful signin and access control for profile retrieval.